### PR TITLE
remove const methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safer-bytes"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2018"
 description = "safe, non-panicking wrappers around the 'bytes' crate"
 license = "MIT"
@@ -14,3 +14,10 @@ categories = ["network-programming", "data-structures"]
 bytes = "1.0.1"
 paste = "1.0.5"
 thiserror = "1.0.26"
+
+[dev-dependencies]
+criterion = "0.3.5"
+
+[[bench]]
+name = "benchmark"
+harness = false

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,0 +1,23 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use safer_bytes::{BytesMut, SafeBuf};
+
+fn copy_to_slice(_dummy: usize) {
+    let mut buffer = BytesMut::new();
+    buffer.extend_from_slice(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    let output = &mut [0_u8; 6];
+    let _output = buffer.try_copy_to_slice(output).unwrap();
+}
+
+fn copy_to_bytes(_dummy: usize) {
+    let mut buffer = BytesMut::new();
+    buffer.extend_from_slice(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    let _output = buffer.try_copy_to_bytes(6).unwrap();
+}
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("copy_to_slice", |b| b.iter(|| copy_to_slice(black_box(6))));
+    c.bench_function("copy_to_bytes", |b| b.iter(|| copy_to_bytes(black_box(6))));
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 #![warn(clippy::pedantic)]
 
 use bytes::Buf;
-pub use bytes::BufMut;
+pub use bytes::{BufMut, Bytes, BytesMut};
 
 pub mod error;
 mod safe_buf;


### PR DESCRIPTION
closes #7
closes #5 

bench testing the 'const' methods reveals no improvement in performance, therefore I have removed the methods.

I've also renamed the methods to more closely align with the `Bytes` crate, so this is a breaking change.

I also discovered that the 'peek' methods don't work as intended, so have removed them.